### PR TITLE
Bump Avalonia to 11.0.999-cibuild0023734-beta

### DIFF
--- a/DialogHost.Avalonia/DialogHost.Avalonia.csproj
+++ b/DialogHost.Avalonia/DialogHost.Avalonia.csproj
@@ -28,6 +28,6 @@
         </AvaloniaResource>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.0.999-cibuild0023583-beta" />
+        <PackageReference Include="Avalonia" Version="11.0.999-cibuild0023734-beta" />
     </ItemGroup>
 </Project>

--- a/DialogHost.Demo.Desktop/DialogHostDemo.Desktop.csproj
+++ b/DialogHost.Demo.Desktop/DialogHostDemo.Desktop.csproj
@@ -7,11 +7,11 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Avalonia" Version="11.0.999-cibuild0023583-beta" />
-		<PackageReference Include="Avalonia.Desktop" Version="11.0.999-cibuild0023583-beta" />
-		<PackageReference Include="Avalonia.Diagnostics" Version="11.0.999-cibuild0023583-beta" />
-		<PackageReference Include="Avalonia.ReactiveUI" Version="11.0.999-cibuild0023583-beta" />
-		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.999-cibuild0023583-beta" />
+		<PackageReference Include="Avalonia" Version="11.0.999-cibuild0023734-beta" />
+		<PackageReference Include="Avalonia.Desktop" Version="11.0.999-cibuild0023734-beta" />
+		<PackageReference Include="Avalonia.Diagnostics" Version="11.0.999-cibuild0023734-beta" />
+		<PackageReference Include="Avalonia.ReactiveUI" Version="11.0.999-cibuild0023734-beta" />
+		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.999-cibuild0023734-beta" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/DialogHost.Demo.Web/DialogHostDemo.Web.csproj
+++ b/DialogHost.Demo.Web/DialogHostDemo.Web.csproj
@@ -11,7 +11,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Avalonia.Web.Blazor" Version="11.0.999-cibuild0023583-beta">
+		<PackageReference Include="Avalonia.Web.Blazor" Version="11.0.999-cibuild0023734-beta">
 			<IncludeAssets>all</IncludeAssets>
 			<ExcludeAssets>contentFiles</ExcludeAssets>
 		</PackageReference>

--- a/DialogHost.Demo/DialogHostDemo.csproj
+++ b/DialogHost.Demo/DialogHostDemo.csproj
@@ -9,10 +9,10 @@
         <AvaloniaResource Include="Assets\**" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.0.999-cibuild0023583-beta" />
-        <PackageReference Include="Avalonia.Diagnostics" Version="11.0.999-cibuild0023583-beta" />
-        <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.999-cibuild0023583-beta" />
-        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.999-cibuild0023583-beta" />
+        <PackageReference Include="Avalonia" Version="11.0.999-cibuild0023734-beta" />
+        <PackageReference Include="Avalonia.Diagnostics" Version="11.0.999-cibuild0023734-beta" />
+        <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.999-cibuild0023734-beta" />
+        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.999-cibuild0023734-beta" />
     </ItemGroup>
     <ItemGroup>
       <ProjectReference Include="..\DialogHost.Avalonia\DialogHost.Avalonia.csproj" />


### PR DESCRIPTION
Published as `DialogHost.Avalonia.0.5.0-rc3` to https://gitlab.com/api/v4/projects/32953869/packages/nuget/index.json